### PR TITLE
Add logging library

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "figlet": "^1.2.1",
     "graphql-request": "^1.8.2",
     "graphql-tag": "^2.10.1",
+    "js-logger": "^1.6.0",
     "nodemon": "^1.18.10",
     "path": "^0.12.7",
     "prettier": "^1.16.4",

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -15,7 +15,7 @@
  */
 
 import { mockProcessStdout } from 'jest-mock-process';
-import { checkFile, parseJsonFileContent } from './cli';
+import { parseJsonFileContent } from './cli';
 
 describe('cli', () => {
   let mockStdout: any;
@@ -25,28 +25,6 @@ describe('cli', () => {
 
   beforeEach(() => {
     mockStdout = mockProcessStdout();
-  });
-
-  describe('checkFile functionality', () => {
-    it('if valid json file provided, no error thrown', () => {
-      const filename = 'hey/its/me/te.st.json';
-      expect(() => checkFile(filename)).not.toThrow();
-    });
-
-    it('if file is not .json format, throw an exception', () => {
-      const filename = 'test.text';
-      expect(() => checkFile(filename)).toThrow();
-    });
-
-    it('if .json is in the path but it is not a valid json file, throw an exception', () => {
-      const filename = '.json/test.text';
-      expect(() => checkFile(filename)).toThrow();
-    });
-
-    it('if file does not have a filename, throw an exception', () => {
-      const filename = 'apples';
-      expect(() => checkFile(filename)).toThrow();
-    });
   });
 
   describe('parseJsonFileContent functionality', () => {

--- a/src/jsonProcessor.ts
+++ b/src/jsonProcessor.ts
@@ -1,7 +1,9 @@
 import Ajv from 'ajv';
+import {createLogger} from './logger';
 import schema from './schema/jsonSchema.json';
 import TopoInterface from './topoInterface';
 
+const log = createLogger('jsonProcessor');
 const ajv = new Ajv();
 const validate = ajv.compile(schema);
 
@@ -28,6 +30,8 @@ export default class JsonProcessor {
   process = async (json: any) => {
     const valid = validate(json);
     if (!valid) {
+      log.error('JSON does not match schema')
+      log.warn(JSON.stringify(validate.errors))
       throw new Error(`Schema not valid: ${validate.errors}`);
     }
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,0 +1,9 @@
+import Logger from 'js-logger';
+
+Logger.useDefaults();
+
+export const createLogger = (name: string) => {
+  return Logger.get(name);
+};
+
+export default Logger;

--- a/src/topoInterface.ts
+++ b/src/topoInterface.ts
@@ -1,4 +1,6 @@
 import {request} from 'graphql-request';
+import {createLogger} from './logger';
+const log = createLogger('topoInterface');
 
 export default class TopoInterface {
   host: string;
@@ -31,9 +33,9 @@ export default class TopoInterface {
 
     try {
       const data = await request(this.host, query, variables);
-      console.log('Created box: ', data);
+      log.info('Created box:', (data as any).createBox.name);
     } catch (error) {
-      console.error('Could not create box: ', error);
+      log.error('Error creating box:', error.toString());
     }
   };
 
@@ -66,9 +68,9 @@ export default class TopoInterface {
 
     try {
       const data = await request(this.host, query, variables);
-      console.log('Created box: ', data);
+      log.info('Created System:', (data as any).createSystem.name);
     } catch (error) {
-      console.error('Could not create box: ', error);
+      log.error('Error creating system: ', error.toString());
     }
   };
 
@@ -92,9 +94,9 @@ export default class TopoInterface {
 
     try {
       const data = await request(this.host, query, variables);
-      console.log('Created technology: ', data);
+      log.info('Created technology:', (data as any).createTechnology.name);
     } catch (error) {
-      console.error('Could not create technology: ', error);
+      log.error('Error creating technology:', error.toString());
     }
   };
 
@@ -107,9 +109,9 @@ export default class TopoInterface {
 
     try {
       await request(this.host, query);
-      console.log("Deleted existing data");
+      log.warn("Deleted existing data");
     } catch (error) {
-      console.error('Could not delete existing data: ', error);
+      log.error('Error deleting existing data:', error.toString());
     }
   };
 }

--- a/tslint.json
+++ b/tslint.json
@@ -14,7 +14,6 @@
     "jsRules": {},
     "rules": {
       "variable-name": ["allow-leading-underscore"],
-      "no-console": [false],
       "member-access": [false],
       "object-literal-sort-keys": [false]
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2946,6 +2946,11 @@ jest@^24.1.0:
     import-local "^2.0.0"
     jest-cli "^24.1.0"
 
+js-logger@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/js-logger/-/js-logger-1.6.0.tgz#7abae5cfaf208c965f3ef20754533bb9e79c7aef"
+  integrity sha512-K4kt2AdD0jUYINbe00BPPpsL65u/rdYOgfaBBVWm/mid+ANk7qxDnoXgKI5ilm49Sjmach2Dzlc+5VxKdRA3tw==
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"


### PR DESCRIPTION
Previously logging was all done via console.log and console.error. According to the [tslint rules](https://palantir.github.io/tslint/rules/no-console/) console logs aren't appropriate for production code. But more generally if we wanted to migrate to have a log file or similar, it would require a fair bit of refactoring. 

I've added in a simple logging library called js-logger. It has the ability to add handlers which could then output to files, external services etc.

Because of this I was also able to remove the custom tslint rule allowing console logs